### PR TITLE
Missing "last_name" validation on budy address adapter model

### DIFF
--- a/src/eadapters/models/address.py
+++ b/src/eadapters/models/address.py
@@ -36,6 +36,7 @@ class EAddress(base.EBase):
             appier.not_empty("first_name"),
 
             appier.not_null("last_name"),
+            appier.not_empty("last_name"),
 
             appier.not_null("address"),
             appier.not_empty("address"),

--- a/src/eadapters/models/budy/bd_address.py
+++ b/src/eadapters/models/budy/bd_address.py
@@ -11,12 +11,6 @@ class BDAddress(address.EAddress, bd_common.BDCommon):
 
     key = appier.field()
 
-    @classmethod
-    def validate(cls):
-        return super(BDAddress, cls).validate() + [
-            appier.not_empty("last_name")
-        ]
-
     @bd_common.handle_error
     def create_s(self):
         api = self._get_api()

--- a/src/eadapters/models/budy/bd_address.py
+++ b/src/eadapters/models/budy/bd_address.py
@@ -11,6 +11,12 @@ class BDAddress(address.EAddress, bd_common.BDCommon):
 
     key = appier.field()
 
+    @classmethod
+    def validate(cls):
+        return super(BDAddress, cls).validate() + [
+            appier.not_empty("last_name")
+        ]
+
     @bd_common.handle_error
     def create_s(self):
         api = self._get_api()


### PR DESCRIPTION
This field is being validated in the budy model and not in the respective adapter model. Can't put this on EAddress because this field is not mandatory in FF.
